### PR TITLE
Upgrade to latest version of Hugo

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         VARIANT: "hugo"
         # Update VERSION to pick a specific hugo version.
         # Example versions: latest, 0.73.0, 0,71.1
-        VERSION: "0.120.2"
+        VERSION: "0.143.1"
 
     env_file:
       - ../.env

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: "0.120.2"
+          hugo-version: "0.143.1"
           extended: true
       - name: Build with Hugo
         env:


### PR DESCRIPTION
Upgrade Hugo to v0.143.1. This also allows us to upgrade to the latest version of blowfish. 