### PR TITLE
Bump blowfish to v2.98

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         VARIANT: "hugo"
         # Update VERSION to pick a specific hugo version.
         # Example versions: latest, 0.73.0, 0,71.1
-        VERSION: "0.143.1"
+        VERSION: "0.155.3"
 
     env_file:
       - ../.env

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: "0.143.1"
+          hugo-version: "0.155.3"
           extended: true
       - name: Build with Hugo
         env:

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -9,7 +9,6 @@ defaultContentLanguage = "en"
 # pluralizeListTitles = "true" # hugo function useful for non-english languages, find out more in  https://gohugo.io/getting-started/configuration/#pluralizelisttitles
 
 enableRobotsTXT = true
-paginate = 10
 summaryLength = 0
 
 buildDrafts = false

--- a/content/posts/calendar_apps/index.md
+++ b/content/posts/calendar_apps/index.md
@@ -123,4 +123,4 @@ I’ve decided to stop the endless search. While the subscription is a considera
 [^1]: You can read more about this topic in [Deep Work by Cal Newport](https://calnewport.com/deep-work-rules-for-focused-success-in-a-distracted-world/).
 [^2]: Of course there is no option to just hide the paid options 😫
 [^3]: You keep the app forever, but pay a renewal fee for future feature/OS compatibility updates.
-[^4]: I’m not the only person who came to this conclusion [it seems](<(https://sixcolors.com/post/2024/01/there-and-back-again-foregoing-fantastical/)>).
+[^4]: I’m not the only person who came to this conclusion [it seems](https://sixcolors.com/post/2024/01/there-and-back-again-foregoing-fantastical/).


### PR DESCRIPTION
- Updates Hugo to v0.155.3
- Updates blowfish to 2.98
- Fixes a typo which new versions of Hugo don't like