### PR TITLE
Replace Gemini with Claude Code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,8 @@
 			"extensions": [
 				"budparr.language-hugo-vscode",
 				"esbenp.prettier-vscode",
-				"tamasfe.even-better-toml"
+				"tamasfe.even-better-toml",
+				"anthropic.claude-code"
 			]
 		}
 	},
@@ -26,10 +27,13 @@
 		1313
 	],
 	"remoteUser": "vscode",
+	"remoteEnv": {
+		"ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}"
+	},
 	"features": {
-		"ghcr.io/stu-bell/devcontainer-features/gemini-cli:0": {}
+		"ghcr.io/anthropics/devcontainer-features/claude-code:1": {}
 	},
 	"mounts": [
-		"source=${localEnv:HOME}/.gemini,target=/home/vscode/.gemini,type=bind,consistency=cached"
+		"source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached"
 	]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+	"recommendations": [
+		"budparr.language-hugo-vscode",
+		"esbenp.prettier-vscode",
+		"tamasfe.even-better-toml",
+		"anthropic.claude-code"
+	]
+}

--- a/website.code-workspace
+++ b/website.code-workspace
@@ -32,7 +32,7 @@
 			"budparr.language-hugo-vscode",
 			"esbenp.prettier-vscode",
 			"tamasfe.even-better-toml",
-			"google.gemini-cli-vscode-ide-companion"
+			"anthropic.claude-code"
 		]
 	}
 }


### PR DESCRIPTION
## Summary
- Swap `gemini-cli` devcontainer feature for `ghcr.io/anthropics/devcontainer-features/claude-code:1`
- Mount `~/.claude` instead of `~/.gemini` and pass `ANTHROPIC_API_KEY` as remote env var
- Replace `google.gemini-cli-vscode-ide-companion` with `anthropic.claude-code` in devcontainer extensions, workspace file, and new `.vscode/extensions.json`

## Test plan
- [x] Rebuild devcontainer and verify Claude Code is installed and authenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)