### PR TITLE
Rationalise tags across all posts

### DIFF
--- a/content/posts/calendar_apps/index.md
+++ b/content/posts/calendar_apps/index.md
@@ -1,7 +1,7 @@
 +++
 title = 'The Quest for the perfect MacOS Calendar App'
 date = 2025-12-21T17:05:44Z
-tags = ['apps']
+tags = ['apps', 'productivity']
 +++
 
 In principle, a calendar app is nothing more than a digital list of events. It should be simple, yet in our age of digital noise and constant distraction, it becomes the our most important tool for managing our time [^1].

--- a/content/posts/calendar_apps/index.md
+++ b/content/posts/calendar_apps/index.md
@@ -1,7 +1,7 @@
 +++
 title = 'The Quest for the perfect MacOS Calendar App'
 date = 2025-12-21T17:05:44Z
-tags = ['apps', 'productivity']
+tags = ['productivity', 'review']
 +++
 
 In principle, a calendar app is nothing more than a digital list of events. It should be simple, yet in our age of digital noise and constant distraction, it becomes the our most important tool for managing our time [^1].

--- a/content/posts/claude_code_vs_gemini/index.md
+++ b/content/posts/claude_code_vs_gemini/index.md
@@ -1,7 +1,7 @@
 +++
 title = 'Tried to save £18/month on Claude Code, wasted £5 in one evening on Gemini'
 date = 2026-03-27T23:06:00Z
-tags = ['development', 'homelab', 'agents']
+tags = ['tooling', 'homelab', 'agents']
 +++
 
 I recently set up an old Dell PC running Ubuntu server as my homelab. It threw up the usual networking and permissions issues, and I thought an AI coding agent would massively speed up the debugging. I'll walk through one task as an example (setting up a Samba share for Time Machine backups), which ended up highlighting the difference in utility between the agents pretty starkly.

--- a/content/posts/devcontainers/index.md
+++ b/content/posts/devcontainers/index.md
@@ -1,7 +1,7 @@
 +++
 title = 'Dev containers are awesome'
 date = 2024-03-01T18:35:54Z
-tags = ['development']
+tags = ['devops']
 +++
 
 I personally love finding ways to reduce friction in my life easier and optimise my processes [^1]. The best tools are the ones which fit in easily to your workflow, and make you wonder how you worked without them before. Dev containers are one of those tools for me, and I’m going to explain why I like them so much.

--- a/content/posts/keychron_v1_max/index.md
+++ b/content/posts/keychron_v1_max/index.md
@@ -1,7 +1,7 @@
 +++
 title = 'My Mechanical Keyboard Journey: Keychron V1 Max Review'
 date = 2025-03-06T21:41:20Z
-tags = ['review']
+tags = ['review', 'hardware']
 +++
 
 I’ve been using a Logitech MX Keys for a while now, and while it’s a solid keyboard, it’s a bit on the large side. I wanted something more compact, with a better typing experience—so I started looking into mechanical keyboards.

--- a/content/posts/latex/index.md
+++ b/content/posts/latex/index.md
@@ -1,7 +1,7 @@
 +++
 title = 'CI for your CV'
 date = 2024-08-12T08:46:08Z
-tags=['development', 'latex']
+tags = ['tooling', 'typesetting']
 +++
 
 I have recently started to use LaTeX again to write my CV after a long hiatus. A lot has changed since I wrote my PhD thesis using LaTeX back in 2020, both in terms of the available tooling and my knowledge of modern software development practices. Therefore I made some significant updates to my LaTeX workflow which I will describe below.

--- a/content/posts/typst/index.md
+++ b/content/posts/typst/index.md
@@ -1,7 +1,7 @@
 +++
 title = 'My LaTeX devcontainer broke. So I tried Typst instead.'
 date = 2026-03-08T23:55:00Z
-tags = ['development', 'latex']
+tags = ['tooling', 'typesetting']
 +++
 
 ## The trigger: a new TeX Live release

--- a/content/posts/why_hugo/index.md
+++ b/content/posts/why_hugo/index.md
@@ -1,7 +1,7 @@
 +++
 title = 'Why Hugo instead of Jekyll?'
 date = 2023-12-19T10:16:13Z
-tags = ['hugo', 'development']
+tags = ['website', 'devops']
 +++
 
 I built this website as a platform for giving updates on my projects and sharing my thoughts. As someone who builds software and interacts with GitHub on a daily basis, the natural choice for hosting a website was [GitHub Pages](https://pages.github.com/). It’s completely free and you don’t even have to create another account. The only limitation is that it can only host static sites, but that’s not really an issue for simple text-heavy websites such as blogs.

--- a/content/projects/googly-eyes/index.md
+++ b/content/projects/googly-eyes/index.md
@@ -1,7 +1,7 @@
 +++
 title = 'Googly Eyes'
 date = 2024-02-08T14:00:00Z
-tags = ['computer vision', 'deployment']
+tags = ['machine learning', 'computer vision', 'deployment']
 +++
 
 {{< katex >}}

--- a/content/projects/googly-eyes/index.md
+++ b/content/projects/googly-eyes/index.md
@@ -1,7 +1,7 @@
 +++
 title = 'Googly Eyes'
 date = 2024-02-08T14:00:00Z
-tags = ['machine learning', 'computer vision', 'deployment']
+tags = ['machine learning', 'deep learning', 'computer vision', 'deployment']
 +++
 
 {{< katex >}}


### PR DESCRIPTION
## Summary

- Replace generic `development` tag with more specific `tooling` or `devops`
- Add `typesetting` tag to latex and typst posts (replacing product-specific `latex` tag)
- Add `website` tag to Hugo post, drop product-specific `hugo` tag
- Add `hardware` to keychron post
- Add `productivity` to calendar apps post

🤖 Generated with [Claude Code](https://claude.com/claude-code)